### PR TITLE
Fix broken "examples" link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ copy, just clone the repo:
 Examples
 --------
 
-See `the examples directory <https://github.com/simoninireland/epyc/tree/main/doc/examples>`_ for code examples.
+See `the examples directory <https://github.com/simoninireland/epyc/tree/master/doc/examples>`_ for code examples.
 
 
 Documentation


### PR DESCRIPTION
Hello,

I've noticed that the "examples" link was broken in the Readme file, as well as the PyPI page (which I think is automatically populated from the readme?), and I'm submitting this PR for the link to be updated (from `main` -> `master`).

Please, feel free to reject and close this PR, if your intention has been to rename the `master` branch to `main`, in the meantime. If this has been the case, indeed, please, note that there's another existing Readme link pointing to the `master` branch (namely, https://github.com/simoninireland/epyc/blob/master/doc/epyc.ipynb).

Thanks!